### PR TITLE
Immediate value for final state

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -86,12 +86,20 @@ func (a *agent) updateValues(env environment) {
 	// i is the index of a.stateHistory array
 	for i := len(a.stateHistory) - 1; i >= 0; i-- {
 		state := a.stateHistory[i]
-		existingValue, ok := a.values[state]
-		if !ok {
-			// agent has no record of this state, use a default value
-			existingValue = defaultValue()
+		var updatedValue float64
+		if target == reward {
+			// If the state is the final state, the value is the reward. The agent should
+			// learn this value by heart and there's no need to update it anymore.
+			updatedValue = target
+		} else {
+			// If the state is no the final state, update its value in the regular way
+			existingValue, ok := a.values[state]
+			if !ok {
+				// agent has no memory of this state, set to defaultValue
+				existingValue = defaultValue()
+			}
+			updatedValue = existingValue + a.alpha*(target-existingValue)
 		}
-		updatedValue := existingValue + a.alpha*(target-existingValue)
 		a.values[state] = updatedValue
 		target = updatedValue
 	}


### PR DESCRIPTION
In the python example, all possible states are assigned a default value before the game starts. In my code, the agent assigns the default value when seeing the state the first time. The value of the final state of each game (with the whole board occupied) is based on the reward only and there's no need to update it.